### PR TITLE
Add the real server address as a reserved property in the metadata

### DIFF
--- a/src/application_protocols/dubbo/dubbo_codec.cc
+++ b/src/application_protocols/dubbo/dubbo_codec.cc
@@ -56,8 +56,10 @@ void DubboCodec::encode(const MetaProtocolProxy::Metadata& metadata,
                         const MetaProtocolProxy::Mutation& mutation, Buffer::Instance& buffer) {
   (void)buffer;
   for (const auto& keyValue : mutation) {
-    ENVOY_LOG(info, "dubbo: codec mutation {} : {}", keyValue.first, keyValue.second);
+    ENVOY_LOG(debug, "dubbo: codec mutation {} : {}", keyValue.first, keyValue.second);
   }
+  ENVOY_LOG(debug, "dubbo: codec server real address: {} ",
+		              metadata.getString(Metadata::HEADER_REAL_SERVER_ADDRESS));
 
   //ASSERT(buffer.length() == 0);
   switch (metadata.getMessageType()) {
@@ -66,6 +68,10 @@ void DubboCodec::encode(const MetaProtocolProxy::Metadata& metadata,
     break;
   }
   case MetaProtocolProxy::MessageType::Request: {
+    // TODO
+    break;
+  }
+  case MetaProtocolProxy::MessageType::Response: {
     // TODO
     break;
   }

--- a/src/application_protocols/thrift/thrift_codec.cc
+++ b/src/application_protocols/thrift/thrift_codec.cc
@@ -105,9 +105,9 @@ void ThriftCodec::encode(const MetaProtocolProxy::Metadata& metadata,
                          const MetaProtocolProxy::Mutation& mutation, Buffer::Instance& buffer) {
   (void)buffer;
   for (const auto& keyValue : mutation) {
-    ENVOY_LOG(info, "thrift: codec mutation {} : {}", keyValue.first, keyValue.second);
+    ENVOY_LOG(debug, "thrift: codec mutation {} : {}", keyValue.first, keyValue.second);
   }
-  ENVOY_LOG(info, "thrift: codec server real ip {} ",
+  ENVOY_LOG(debug, "thrift: codec server real address: {} ",
             metadata.getString(Metadata::HEADER_REAL_SERVER_ADDRESS));
   // ASSERT(buffer.length() == 0);
   switch (metadata.getMessageType()) {

--- a/src/application_protocols/thrift/thrift_codec.cc
+++ b/src/application_protocols/thrift/thrift_codec.cc
@@ -108,12 +108,19 @@ void ThriftCodec::encode(const MetaProtocolProxy::Metadata& metadata,
     ENVOY_LOG(info, "thrift: codec mutation {} : {}", keyValue.first, keyValue.second);
   }
 
+  ENVOY_LOG(info, "thrift: codec server real ip {} ",
+            metadata.getString(Metadata::HEADER_REAL_SERVER_ADDRESS));
+
   // ASSERT(buffer.length() == 0);
   switch (metadata.getMessageType()) {
   case MetaProtocolProxy::MessageType::Heartbeat: {
     break;
   }
   case MetaProtocolProxy::MessageType::Request: {
+    // TODO
+    break;
+  }
+  case MetaProtocolProxy::MessageType::Response: {
     // TODO
     break;
   }
@@ -594,4 +601,3 @@ ProtocolState DecoderStateMachine::run(Buffer::Instance& buffer) {
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy
-

--- a/src/meta_protocol_proxy/active_message.cc
+++ b/src/meta_protocol_proxy/active_message.cc
@@ -50,8 +50,8 @@ void ActiveResponseDecoder::onStreamDecoded(MetadataSharedPtr metadata,
   }
 
   // put real server ip in the response
-  metadata_->putString(Metadata::HEADER_REAL_SERVER_IP,
-                       requestMetadata_.getString(Metadata::HEADER_REAL_SERVER_IP));
+  metadata_->putString(Metadata::HEADER_REAL_SERVER_ADDRESS,
+                       requestMetadata_.getString(Metadata::HEADER_REAL_SERVER_ADDRESS));
   // TODO support response mutation
   codec_->encode(*metadata_, Mutation{}, metadata->getOriginMessage());
   response_connection_.write(metadata->getOriginMessage(), false);

--- a/src/meta_protocol_proxy/active_message.cc
+++ b/src/meta_protocol_proxy/active_message.cc
@@ -14,9 +14,11 @@ namespace MetaProtocolProxy {
 // class ActiveResponseDecoder
 ActiveResponseDecoder::ActiveResponseDecoder(ActiveMessage& parent, MetaProtocolProxyStats& stats,
                                              Network::Connection& connection,
-                                             std::string applicationProtocol, CodecPtr&& codec)
+                                             std::string applicationProtocol, CodecPtr&& codec,
+                                             Metadata& requestMetadata)
     : parent_(parent), stats_(stats), response_connection_(connection),
       application_protocol_(applicationProtocol), codec_(std::move(codec)),
+      requestMetadata_(requestMetadata),
       decoder_(std::make_unique<ResponseDecoder>(*codec_, *this)), complete_(false),
       response_status_(UpstreamResponseStatus::MoreData) {}
 
@@ -47,6 +49,11 @@ void ActiveResponseDecoder::onStreamDecoded(MetadataSharedPtr metadata,
     throw DownstreamConnectionCloseException("Downstream has closed or closing");
   }
 
+  // put real server ip in the response
+  metadata_->putString(Metadata::HEADER_REAL_SERVER_IP,
+                       requestMetadata_.getString(Metadata::HEADER_REAL_SERVER_IP));
+  // TODO support response mutation
+  codec_->encode(*metadata_, Mutation{}, metadata->getOriginMessage());
   response_connection_.write(metadata->getOriginMessage(), false);
   ENVOY_LOG(debug,
             "meta protocol {} response: the upstream response message has been forwarded to the "
@@ -149,7 +156,9 @@ void ActiveMessageDecoderFilter::sendLocalReply(const DirectResponse& response, 
   parent_.sendLocalReply(response, end_stream);
 }
 
-void ActiveMessageDecoderFilter::startUpstreamResponse() { parent_.startUpstreamResponse(); }
+void ActiveMessageDecoderFilter::startUpstreamResponse(Metadata& requestMetadata) {
+  parent_.startUpstreamResponse(requestMetadata);
+}
 
 UpstreamResponseStatus ActiveMessageDecoderFilter::upstreamData(Buffer::Instance& buffer) {
   return parent_.upstreamData(buffer);
@@ -159,9 +168,7 @@ void ActiveMessageDecoderFilter::resetDownstreamConnection() {
   parent_.resetDownstreamConnection();
 }
 
-CodecPtr ActiveMessageDecoderFilter::createCodec() {
-  return parent_.createCodec();
-}
+CodecPtr ActiveMessageDecoderFilter::createCodec() { return parent_.createCodec(); }
 
 // class ActiveMessageEncoderFilter
 ActiveMessageEncoderFilter::ActiveMessageEncoderFilter(ActiveMessage& parent,
@@ -362,7 +369,7 @@ void ActiveMessage::sendLocalReply(const DirectResponse& response, bool end_stre
   local_response_sent_ = true;
 }
 
-void ActiveMessage::startUpstreamResponse() {
+void ActiveMessage::startUpstreamResponse(Metadata& requestMetadata) {
   ENVOY_LOG(debug, "meta protocol response: start upstream");
 
   ASSERT(response_decoder_ == nullptr);
@@ -372,7 +379,7 @@ void ActiveMessage::startUpstreamResponse() {
   // Create a response message decoder.
   response_decoder_ = std::make_unique<ActiveResponseDecoder>(
       *this, parent_.stats(), parent_.connection(), parent_.config().applicationProtocol(),
-      std::move(codec));
+      std::move(codec), requestMetadata);
 }
 
 UpstreamResponseStatus ActiveMessage::upstreamData(Buffer::Instance& buffer) {
@@ -414,9 +421,7 @@ void ActiveMessage::resetDownstreamConnection() {
   parent_.connection().close(Network::ConnectionCloseType::NoFlush);
 }
 
-CodecPtr ActiveMessage::createCodec() {
-  return parent_.config().createCodec();
-}
+CodecPtr ActiveMessage::createCodec() { return parent_.config().createCodec(); }
 
 void ActiveMessage::resetStream() { parent_.deferredMessage(*this); }
 

--- a/src/meta_protocol_proxy/active_message.h
+++ b/src/meta_protocol_proxy/active_message.h
@@ -32,7 +32,7 @@ class ActiveResponseDecoder : public ResponseDecoderCallbacks,
 public:
   ActiveResponseDecoder(ActiveMessage& parent, MetaProtocolProxyStats& stats,
                         Network::Connection& connection, std::string applicationProtocol,
-                        CodecPtr&& codec);
+                        CodecPtr&& codec, Metadata& requestMetadata);
   ~ActiveResponseDecoder() override = default;
 
   UpstreamResponseStatus onData(Buffer::Instance& data);
@@ -54,6 +54,7 @@ private:
   Network::Connection& response_connection_;
   std::string application_protocol_;
   CodecPtr codec_;
+  Metadata& requestMetadata_;
   ResponseDecoderPtr decoder_;
   MetadataSharedPtr metadata_;
   bool complete_ : 1;
@@ -97,7 +98,7 @@ public:
 
   void continueDecoding() override;
   void sendLocalReply(const DirectResponse& response, bool end_stream) override;
-  void startUpstreamResponse() override;
+  void startUpstreamResponse(Metadata& requestMetadata) override;
   UpstreamResponseStatus upstreamData(Buffer::Instance& buffer) override;
   void resetDownstreamConnection() override;
   CodecPtr createCodec() override;
@@ -171,7 +172,7 @@ public:
   StreamInfo::StreamInfo& streamInfo() override;
   Route::RouteConstSharedPtr route() override;
   void sendLocalReply(const DirectResponse& response, bool end_stream) override;
-  void startUpstreamResponse() override;
+  void startUpstreamResponse(Metadata& requestMetadata) override;
   UpstreamResponseStatus upstreamData(Buffer::Instance& buffer) override;
   void resetDownstreamConnection() override;
   CodecPtr createCodec() override;

--- a/src/meta_protocol_proxy/codec/codec.h
+++ b/src/meta_protocol_proxy/codec/codec.h
@@ -77,7 +77,8 @@ public:
 
 class Metadata : public Properties {
 public:
-  inline static const std::string HEADER_REAL_SERVER_IP = "x-meta-protocol-real-server-ip";
+  inline static const std::string HEADER_REAL_SERVER_ADDRESS =
+      "x-meta-protocol-real-server-address";
 
   virtual ~Metadata() = default;
 

--- a/src/meta_protocol_proxy/codec/codec.h
+++ b/src/meta_protocol_proxy/codec/codec.h
@@ -77,6 +77,8 @@ public:
 
 class Metadata : public Properties {
 public:
+  inline static const std::string HEADER_REAL_SERVER_IP = "x-meta-protocol-real-server-ip";
+
   virtual ~Metadata() = default;
 
   virtual void setOriginMessage(Buffer::Instance&) PURE;

--- a/src/meta_protocol_proxy/decoder.h
+++ b/src/meta_protocol_proxy/decoder.h
@@ -108,6 +108,7 @@ public:
    * Drains data from the given buffer
    *
    * @param data a Buffer containing protocol data
+   * as the server real ip address
    * @throw EnvoyException on protocol errors
    */
   FilterStatus onData(Buffer::Instance& data, bool& buffer_underflow);

--- a/src/meta_protocol_proxy/filters/filter.h
+++ b/src/meta_protocol_proxy/filters/filter.h
@@ -120,10 +120,9 @@ public:
 
   /**
    * Indicates the start of an upstream response. May only be called once.
-   * @param transport_type TransportType the upstream is using
-   * @param protocol_type ProtocolType the upstream is using
+   * @param requestMetadata we need request metadata to encode response, such as the real server ip
    */
-  virtual void startUpstreamResponse() PURE;
+  virtual void startUpstreamResponse(Metadata& requestMetadata) PURE;
 
   /**
    * Called with upstream response data.

--- a/src/meta_protocol_proxy/filters/router/router.cc
+++ b/src/meta_protocol_proxy/filters/router/router.cc
@@ -283,7 +283,7 @@ void Router::UpstreamRequest::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr
 
   // Store the upstream ip to the metadata, which will be used in the response
   parent_.requestMetadata_->putString(
-      Metadata::HEADER_REAL_SERVER_IP,
+      Metadata::HEADER_REAL_SERVER_ADDRESS,
       conn_data_->connection().addressProvider().remoteAddress()->asString());
 
   onRequestStart(continue_decoding);

--- a/src/meta_protocol_proxy/filters/router/router.h
+++ b/src/meta_protocol_proxy/filters/router/router.h
@@ -100,6 +100,7 @@ private:
 
   std::unique_ptr<UpstreamRequest> upstream_request_;
   Envoy::Buffer::OwnedImpl upstream_request_buffer_;
+  MetadataSharedPtr requestMetadata_;
 
   bool filter_complete_{false};
 };

--- a/test/dubbo/test.sh
+++ b/test/dubbo/test.sh
@@ -4,5 +4,5 @@ docker rm consumer provider server client
 docker run -d --network host --name consumer --env mode=demo aeraki/dubbo-sample-consumer
 docker run -d -p 20881:20880 --name provider aeraki/dubbo-sample-provider
 kill `ps -ef | awk '/bazel-bin\/envoy/{print $2}'`
-$BASEDIR/../../bazel-bin/envoy -c $BASEDIR/test.yaml &
+$BASEDIR/../../bazel-bin/envoy -c $BASEDIR/test.yaml -l debug&
 docker logs -f consumer


### PR DESCRIPTION
Add the real server address as a reserved property in the metadata

How to get the real server address:

```
void DubboCodec::encode(const MetaProtocolProxy::Metadata& metadata,
                        const MetaProtocolProxy::Mutation& mutation, Buffer::Instance& buffer) {
  
  ENVOY_LOG(debug, "dubbo: server real address: {} ",
		              metadata.getString(Metadata::HEADER_REAL_SERVER_ADDRESS));
 ......
}
```

Related issue: Expose endpoint IP from meta-protocol #178