### PR TITLE
Rate limit metrics

### DIFF
--- a/src/meta_protocol_proxy/filters/local_ratelimit/BUILD
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/BUILD
@@ -24,7 +24,7 @@ envoy_cc_library(
     name = "local_ratelimit",
     repository = "@envoy",
     srcs = ["local_ratelimit.cc"],
-    hdrs = ["local_ratelimit.h"],
+    hdrs = ["local_ratelimit.h", "stats.h"],
     deps = [
         # ":local_ratelimit_manager",
         ":local_ratelimit_impl",

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
@@ -12,7 +12,7 @@ namespace LocalRateLimit {
 
 FilterConfig::FilterConfig(const LocalRateLimitConfig& cfg, Stats::Scope& scope,
                            Event::Dispatcher& dispatcher)
-    : stats_(generateStats(cfg.stat_prefix(), scope)),
+    : stats_(LocalRateLimitStats::generateStats(cfg.stat_prefix(), scope)),
       rate_limiter_(LocalRateLimiterImpl(
           std::chrono::milliseconds(
               PROTOBUF_GET_MS_OR_DEFAULT(cfg.token_bucket(), fill_interval, 0)),
@@ -20,13 +20,6 @@ FilterConfig::FilterConfig(const LocalRateLimitConfig& cfg, Stats::Scope& scope,
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(cfg.token_bucket(), tokens_per_fill, 1), dispatcher,
           cfg.conditions(), cfg)),
       config_(cfg) {}
-
-LocalRateLimitStats FilterConfig::generateStats(const std::string& prefix, Stats::Scope& scope) {
-  const std::string final_prefix = prefix + ".local_rate_limit";
-  std::cout << final_prefix << std::endl << std::endl;
-  std::cout << &scope << std::endl << std::endl;
-  return {ALL_LOCAL_RATE_LIMIT_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
-}
 
 void LocalRateLimit::onDestroy() { cleanup(); }
 
@@ -68,7 +61,7 @@ bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
     return false;
   }
   std::cout << filter_config_->stats_.rate_limited_.value() << std::endl << std::endl;
-  
+
   filter_config_->stats_.rate_limited_.inc();
   return true;
 };
@@ -78,5 +71,4 @@ bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy
-
 

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
@@ -59,7 +59,7 @@ bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
     filter_config_->stats().ok_.inc();
     return false;
   }
-  filter_config_->stats().rate_limited_.inc(10);
+  filter_config_->stats().rate_limited_.inc();
   return true;
 };
 

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
@@ -18,8 +18,7 @@ FilterConfig::FilterConfig(const LocalRateLimitConfig& cfg, Stats::Scope& scope,
               PROTOBUF_GET_MS_OR_DEFAULT(cfg.token_bucket(), fill_interval, 0)),
           cfg.token_bucket().max_tokens(),
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(cfg.token_bucket(), tokens_per_fill, 1), dispatcher,
-          cfg.conditions(), cfg)),
-      config_(cfg) {}
+          cfg.conditions(), cfg)) {}
 
 void LocalRateLimit::onDestroy() { cleanup(); }
 
@@ -56,7 +55,7 @@ FilterStatus LocalRateLimit::onMessageEncoded(MetadataSharedPtr, MutationSharedP
 void LocalRateLimit::cleanup() {}
 
 bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
-  if (filter_config_->rate_limiter_.requestAllowed(metadata)) {
+  if (filter_config_->rateLimiter().requestAllowed(metadata)) {
     filter_config_->stats().ok_.inc();
     return false;
   }

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
@@ -59,10 +59,11 @@ bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
     filter_config_->stats().ok_.inc();
     return false;
   }
-  filter_config_->stats().rate_limited_.inc();
   std::cout << &filter_config_->stats() << std::endl << std::endl;
+  std::cout << &filter_config_->stats().rate_limited_ << std::endl << std::endl;
   std::cout << filter_config_->stats().rate_limited_.value() << std::endl << std::endl;
-
+  std::cout << filter_config_->stats().ok_.value() << std::endl << std::endl;
+  filter_config_->stats().rate_limited_.add(10);
   return true;
 };
 
@@ -71,3 +72,4 @@ bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy
+

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
@@ -59,11 +59,7 @@ bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
     filter_config_->stats().ok_.inc();
     return false;
   }
-  std::cout << &filter_config_->stats() << std::endl << std::endl;
-  std::cout << &filter_config_->stats().rate_limited_ << std::endl << std::endl;
-  std::cout << filter_config_->stats().rate_limited_.value() << std::endl << std::endl;
-  std::cout << filter_config_->stats().ok_.value() << std::endl << std::endl;
-  filter_config_->stats().rate_limited_.add(10);
+  filter_config_->stats().rate_limited_.inc(10);
   return true;
 };
 

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
@@ -59,10 +59,10 @@ bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
     filter_config_->stats().ok_.inc();
     return false;
   }
+  filter_config_->stats().rate_limited_.inc();
   std::cout << &filter_config_->stats() << std::endl << std::endl;
   std::cout << filter_config_->stats().rate_limited_.value() << std::endl << std::endl;
 
-  filter_config_->stats().rate_limited_.inc();
   return true;
 };
 

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
@@ -23,6 +23,8 @@ FilterConfig::FilterConfig(const LocalRateLimitConfig& cfg, Stats::Scope& scope,
 
 LocalRateLimitStats FilterConfig::generateStats(const std::string& prefix, Stats::Scope& scope) {
   const std::string final_prefix = prefix + ".local_rate_limit";
+  std::cout << final_prefix << std::endl << std::endl;
+  std::cout << &scope << std::endl << std::endl;
   return {ALL_LOCAL_RATE_LIMIT_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
 }
 
@@ -65,6 +67,8 @@ bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
     filter_config_->stats_.ok_.inc();
     return false;
   }
+  std::cout << filter_config_->stats_.rate_limited_.value() << std::endl << std::endl;
+  
   filter_config_->stats_.rate_limited_.inc();
   return true;
 };
@@ -74,4 +78,5 @@ bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy
+
 

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
@@ -57,12 +57,13 @@ void LocalRateLimit::cleanup() {}
 
 bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
   if (filter_config_->rate_limiter_.requestAllowed(metadata)) {
-    filter_config_->stats_.ok_.inc();
+    filter_config_->stats().ok_.inc();
     return false;
   }
-  std::cout << filter_config_->stats_.rate_limited_.value() << std::endl << std::endl;
+  std::cout << &filter_config_->stats() << std::endl << std::endl;
+  std::cout << filter_config_->stats().rate_limited_.value() << std::endl << std::endl;
 
-  filter_config_->stats_.rate_limited_.inc();
+  filter_config_->stats().rate_limited_.inc();
   return true;
 };
 
@@ -71,4 +72,3 @@ bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy
-

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.h
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.h
@@ -33,7 +33,7 @@ public:
 
 private:
   mutable LocalRateLimitStats stats_;
-  LocalRateLimiterImpl rate_limiter_;
+  mutable LocalRateLimiterImpl rate_limiter_;
 };
 
 class LocalRateLimit : public CodecFilter, Logger::Loggable<Logger::Id::filter> {

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.h
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.h
@@ -30,10 +30,12 @@ public:
   FilterConfig(const LocalRateLimitConfig& cfg, Stats::Scope& scope, Event::Dispatcher& dispatcher);
   ~FilterConfig() = default;
 
+  LocalRateLimitStats& stats() const { return stats_; }
+
 private:
   LocalRateLimitStats generateStats(const std::string& prefix, Stats::Scope& scope);
 
-  LocalRateLimitStats stats_;
+  mutable LocalRateLimitStats stats_;
   LocalRateLimiterImpl rate_limiter_;
   LocalRateLimitConfig config_;
 };
@@ -57,8 +59,6 @@ private:
 
   bool shouldRateLimit(MetadataSharedPtr metadata);
 
-  LocalRateLimitStats generateStats(const std::string& prefix, Stats::Scope& scope);
-
   DecoderFilterCallbacks* callbacks_{};
   EncoderFilterCallbacks* encoder_callbacks_{};
 
@@ -70,4 +70,3 @@ private:
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy
-

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.h
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.h
@@ -28,12 +28,12 @@ public:
   FilterConfig(const LocalRateLimitConfig& cfg, Stats::Scope& scope, Event::Dispatcher& dispatcher);
   ~FilterConfig() = default;
 
-  LocalRateLimitStats& stats() const { return stats_; }
-  LocalRateLimiterImpl& rateLimiter() const { return rate_limiter_; }
+  LocalRateLimitStats& stats() { return stats_; }
+  LocalRateLimiterImpl& rateLimiter() { return rate_limiter_; }
 
 private:
-  mutable LocalRateLimitStats stats_;
-  mutable LocalRateLimiterImpl rate_limiter_;
+  LocalRateLimitStats stats_;
+  LocalRateLimiterImpl rate_limiter_;
 };
 
 class LocalRateLimit : public CodecFilter, Logger::Loggable<Logger::Id::filter> {

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.h
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.h
@@ -15,26 +15,13 @@
 #include "src/meta_protocol_proxy/filters/filter.h"
 
 #include "src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit_impl.h"
+#include "src/meta_protocol_proxy/filters/local_ratelimit/stats.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace MetaProtocolProxy {
 namespace LocalRateLimit {
-
-/**
- * All local rate limit stats. @see stats_macros.h
- */
-#define ALL_LOCAL_RATE_LIMIT_STATS(COUNTER)                                                        \
-  COUNTER(rate_limited)                                                                            \
-  COUNTER(ok)
-
-/**
- * Struct definition for all local rate limit stats. @see stats_macros.h
- */
-struct LocalRateLimitStats {
-  ALL_LOCAL_RATE_LIMIT_STATS(GENERATE_COUNTER_STRUCT)
-};
 
 class FilterConfig {
   friend class LocalRateLimit;
@@ -46,7 +33,7 @@ public:
 private:
   LocalRateLimitStats generateStats(const std::string& prefix, Stats::Scope& scope);
 
-  mutable LocalRateLimitStats stats_;
+  LocalRateLimitStats stats_;
   LocalRateLimiterImpl rate_limiter_;
   LocalRateLimitConfig config_;
 };

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.h
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.h
@@ -24,20 +24,16 @@ namespace MetaProtocolProxy {
 namespace LocalRateLimit {
 
 class FilterConfig {
-  friend class LocalRateLimit;
-
 public:
   FilterConfig(const LocalRateLimitConfig& cfg, Stats::Scope& scope, Event::Dispatcher& dispatcher);
   ~FilterConfig() = default;
 
   LocalRateLimitStats& stats() const { return stats_; }
+  LocalRateLimiterImpl& rateLimiter() const { return rate_limiter_; }
 
 private:
-  LocalRateLimitStats generateStats(const std::string& prefix, Stats::Scope& scope);
-
   mutable LocalRateLimitStats stats_;
   LocalRateLimiterImpl rate_limiter_;
-  LocalRateLimitConfig config_;
 };
 
 class LocalRateLimit : public CodecFilter, Logger::Loggable<Logger::Id::filter> {

--- a/src/meta_protocol_proxy/filters/local_ratelimit/stats.h
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/stats.h
@@ -24,8 +24,8 @@ namespace LocalRateLimit {
 struct LocalRateLimitStats {
   ALL_LOCAL_RATE_LIMIT_STATS(GENERATE_COUNTER_STRUCT)
 
-  static LocalRateLimitStats generateStats(const std::string& , Stats::Scope& scope) {
-    const std::string final_prefix = "xxxxx.local_rate_limit";
+  static LocalRateLimitStats generateStats(const std::string& prefix, Stats::Scope& scope) {
+    const std::string final_prefix = prefix + ".local_rate_limit";
     std::cout << final_prefix << std::endl << std::endl;
     std::cout << &scope << std::endl << std::endl;
     return {ALL_LOCAL_RATE_LIMIT_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
@@ -37,4 +37,3 @@ struct LocalRateLimitStats {
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy
-

--- a/src/meta_protocol_proxy/filters/local_ratelimit/stats.h
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/stats.h
@@ -24,7 +24,7 @@ namespace LocalRateLimit {
 struct LocalRateLimitStats {
   ALL_LOCAL_RATE_LIMIT_STATS(GENERATE_COUNTER_STRUCT)
 
-  static LocalRateLimitStats generateStats(const std::string& prefix, Stats::Scope& scope) {
+  static LocalRateLimitStats generateStats(const std::string& , Stats::Scope& scope) {
     const std::string final_prefix = "xxxxx.local_rate_limit";
     std::cout << final_prefix << std::endl << std::endl;
     std::cout << &scope << std::endl << std::endl;

--- a/src/meta_protocol_proxy/filters/local_ratelimit/stats.h
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/stats.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+
+#include "envoy/stats/scope.h"
+#include "envoy/stats/stats_macros.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace MetaProtocolProxy {
+namespace LocalRateLimit {
+
+/**
+ * All local rate limit stats. @see stats_macros.h
+ */
+#define ALL_LOCAL_RATE_LIMIT_STATS(COUNTER)                                                        \
+  COUNTER(rate_limited)                                                                            \
+  COUNTER(ok)
+
+/**
+ * Struct definition for all local rate limit stats. @see stats_macros.h
+ */
+struct LocalRateLimitStats {
+  ALL_LOCAL_RATE_LIMIT_STATS(GENERATE_COUNTER_STRUCT)
+
+  static LocalRateLimitStats generateStats(const std::string& prefix, Stats::Scope& scope) {
+    const std::string final_prefix = prefix + ".local_rate_limit";
+    std::cout << final_prefix << std::endl << std::endl;
+    std::cout << &scope << std::endl << std::endl;
+    return {ALL_LOCAL_RATE_LIMIT_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
+  }
+};
+
+} // namespace LocalRateLimit
+} // namespace MetaProtocolProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy
+

--- a/src/meta_protocol_proxy/filters/local_ratelimit/stats.h
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/stats.h
@@ -25,9 +25,7 @@ struct LocalRateLimitStats {
   ALL_LOCAL_RATE_LIMIT_STATS(GENERATE_COUNTER_STRUCT)
 
   static LocalRateLimitStats generateStats(const std::string& prefix, Stats::Scope& scope) {
-    const std::string final_prefix = prefix + ".local_rate_limit";
-    std::cout << final_prefix << std::endl << std::endl;
-    std::cout << &scope << std::endl << std::endl;
+    const std::string final_prefix = "meta_protocol." + prefix + ".local_rate_limit";
     return {ALL_LOCAL_RATE_LIMIT_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
   }
 };

--- a/src/meta_protocol_proxy/filters/local_ratelimit/stats.h
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/stats.h
@@ -25,7 +25,7 @@ struct LocalRateLimitStats {
   ALL_LOCAL_RATE_LIMIT_STATS(GENERATE_COUNTER_STRUCT)
 
   static LocalRateLimitStats generateStats(const std::string& prefix, Stats::Scope& scope) {
-    const std::string final_prefix = prefix + ".local_rate_limit";
+    const std::string final_prefix = "xxxxx.local_rate_limit";
     std::cout << final_prefix << std::endl << std::endl;
     std::cout << &scope << std::endl << std::endl;
     return {ALL_LOCAL_RATE_LIMIT_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};

--- a/test/local-ratelimit/test.sh
+++ b/test/local-ratelimit/test.sh
@@ -7,8 +7,8 @@ docker run -d --network host --name client --env helloServer=localhost --env mod
 docker run -d -p 9091:9090 --name server aeraki/thrift-sample-server
 kill `ps -ef | awk '/bazel-bin\/envoy/{print $2}'`
 #$BASEDIR/../../bazel-bin/envoy -c $BASEDIR/test-full-match-condition.yaml &
-#$BASEDIR/../../bazel-bin/envoy -c $BASEDIR/test-only-global-token.yaml &
+$BASEDIR/../../bazel-bin/envoy -c $BASEDIR/test-only-global-token.yaml &
 #$BASEDIR/../../bazel-bin/envoy -c $BASEDIR/test-full-no-matched-condition.yaml &
 #$BASEDIR/../../bazel-bin/envoy -c $BASEDIR/test-no-global-bucket-match-condition.yaml &
-$BASEDIR/../../bazel-bin/envoy -c $BASEDIR/test-no-global-bucket-no-matched-condition.yaml &
+#$BASEDIR/../../bazel-bin/envoy -c $BASEDIR/test-no-global-bucket-no-matched-condition.yaml &
 docker logs -f client


### PR DESCRIPTION
Relate issue: https://github.com/aeraki-mesh/aeraki/issues/179

*_rate_limit_ok counter: requests enforced rate limiting but are not rate limited
*_rate_limit_rate_limited counter: requests are rate limited
```
➜  ~ aerakictl_sidecar_stats v1 meta-thrift|grep thrift|grep local_rate_limit
# TYPE envoy_meta_protocol_thrift_sample_server_meta_thrift_svc_cluster_local_local_rate_limit_ok counter
envoy_meta_protocol_thrift_sample_server_meta_thrift_svc_cluster_local_local_rate_limit_ok{} 25
# TYPE envoy_meta_protocol_thrift_sample_server_meta_thrift_svc_cluster_local_local_rate_limit_rate_limited counter
envoy_meta_protocol_thrift_sample_server_meta_thrift_svc_cluster_local_local_rate_limit_rate_limited{} 19
```