### PR TITLE
we don't have to pause the dispatch while waiting for the upstream connection

### DIFF
--- a/src/meta_protocol_proxy/active_message.cc
+++ b/src/meta_protocol_proxy/active_message.cc
@@ -149,7 +149,6 @@ void ActiveMessageDecoderFilter::continueDecoding() {
       // If the filter stack was paused during messageEnd, handle end-of-request details.
       activeMessage_.finalizeRequest();
     }
-    activeMessage_.continueDecoding();
   }
 }
 
@@ -520,8 +519,6 @@ uint64_t ActiveMessage::requestId() const {
 }
 
 uint64_t ActiveMessage::streamId() const { return stream_id_; }
-
-void ActiveMessage::continueDecoding() { connection_manager_.continueDecoding(); }
 
 StreamInfo::StreamInfo& ActiveMessage::streamInfo() { return stream_info_; }
 

--- a/src/meta_protocol_proxy/active_message.h
+++ b/src/meta_protocol_proxy/active_message.h
@@ -167,7 +167,7 @@ public:
   uint64_t requestId() const override;
   uint64_t streamId() const override;
   const Network::Connection* connection() const override;
-  void continueDecoding() override;
+  void continueDecoding() override{};            // This method is unused, we may clear it later
   StreamInfo::StreamInfo& streamInfo() override; // todo refactory
   Route::RouteConstSharedPtr route() override;
   void sendLocalReply(const DirectResponse& response, bool end_stream) override;

--- a/src/meta_protocol_proxy/conn_manager.h
+++ b/src/meta_protocol_proxy/conn_manager.h
@@ -74,7 +74,6 @@ public:
   Random::RandomGenerator& randomGenerator() const { return random_generator_; }
   Config& config() const { return config_; }
 
-  void continueDecoding();
   void deferredMessage(ActiveMessage& message);
   void sendLocalReply(Metadata& metadata, const DirectResponse& response, bool end_stream);
 
@@ -94,9 +93,6 @@ private:
   Buffer::OwnedImpl request_buffer_;
   std::list<ActiveMessagePtr> active_message_list_;
   std::map<uint64_t, StreamPtr> active_stream_map_;
-
-  bool stopped_{false};
-  bool half_closed_{false};
 
   Config& config_;
   TimeSource& time_system_;


### PR DESCRIPTION
we don't have to block the dispatching while waiting for the upstream connection, we can continue processing the following requests.

Signed-off-by: zhaohuabing <zhaohuabing@gmail.com>