### PR TITLE
Split StopIteration into two statuses: PauseIteration and AbortIteration

### DIFF
--- a/src/meta_protocol_proxy/active_message.h
+++ b/src/meta_protocol_proxy/active_message.h
@@ -184,7 +184,7 @@ public:
                                    FilterIterationStartState state);
   FilterStatus applyEncoderFilters(ActiveMessageEncoderFilter* filter,
                                    FilterIterationStartState state);
-  void maybeDeferredMessage();
+  void maybeDeferredDeleteMessage();
   void onReset();
   void onError(const std::string& what);
   MetadataSharedPtr metadata() const { return metadata_; }

--- a/src/meta_protocol_proxy/active_message.h
+++ b/src/meta_protocol_proxy/active_message.h
@@ -184,7 +184,7 @@ public:
                                    FilterIterationStartState state);
   FilterStatus applyEncoderFilters(ActiveMessageEncoderFilter* filter,
                                    FilterIterationStartState state);
-  void finalizeRequest();
+  void maybeDeferredMessage();
   void onReset();
   void onError(const std::string& what);
   MetadataSharedPtr metadata() const { return metadata_; }

--- a/src/meta_protocol_proxy/conn_manager.h
+++ b/src/meta_protocol_proxy/conn_manager.h
@@ -74,7 +74,7 @@ public:
   Random::RandomGenerator& randomGenerator() const { return random_generator_; }
   Config& config() const { return config_; }
 
-  void deferredMessage(ActiveMessage& message);
+  void deferredDeleteMessage(ActiveMessage& message);
   void sendLocalReply(Metadata& metadata, const DirectResponse& response, bool end_stream);
 
   Stream& newActiveStream(uint64_t stream_id);

--- a/src/meta_protocol_proxy/decoder.cc
+++ b/src/meta_protocol_proxy/decoder.cc
@@ -42,7 +42,7 @@ DecoderBase::DecoderBase(Codec& codec, MessageType messageType)
 
 DecoderBase::~DecoderBase() { complete(); }
 
-FilterStatus DecoderBase::onData(Buffer::Instance& data, bool& buffer_underflow) {
+void DecoderBase::onData(Buffer::Instance& data, bool& buffer_underflow) {
   ENVOY_LOG(debug, "MetaProtocol decoder: {} bytes available", data.length());
   buffer_underflow = false;
 
@@ -60,7 +60,7 @@ FilterStatus DecoderBase::onData(Buffer::Instance& data, bool& buffer_underflow)
   case ProtocolState::WaitForData:
     ENVOY_LOG(debug, "MetaProtocol decoder: wait for data");
     buffer_underflow = true;
-    return FilterStatus::ContinueIteration;
+    return;
   default:
     break;
   }
@@ -71,7 +71,7 @@ FilterStatus DecoderBase::onData(Buffer::Instance& data, bool& buffer_underflow)
   complete();
   buffer_underflow = (data.length() == 0);
   ENVOY_LOG(debug, "MetaProtocol decoder: data length {}", data.length());
-  return FilterStatus::ContinueIteration;
+  return;
 }
 
 /**

--- a/src/meta_protocol_proxy/decoder.cc
+++ b/src/meta_protocol_proxy/decoder.cc
@@ -60,7 +60,7 @@ FilterStatus DecoderBase::onData(Buffer::Instance& data, bool& buffer_underflow)
   case ProtocolState::WaitForData:
     ENVOY_LOG(debug, "MetaProtocol decoder: wait for data");
     buffer_underflow = true;
-    return FilterStatus::Continue;
+    return FilterStatus::ContinueIteration;
   default:
     break;
   }
@@ -71,7 +71,7 @@ FilterStatus DecoderBase::onData(Buffer::Instance& data, bool& buffer_underflow)
   complete();
   buffer_underflow = (data.length() == 0);
   ENVOY_LOG(debug, "MetaProtocol decoder: data length {}", data.length());
-  return FilterStatus::Continue;
+  return FilterStatus::ContinueIteration;
 }
 
 /**

--- a/src/meta_protocol_proxy/decoder.h
+++ b/src/meta_protocol_proxy/decoder.h
@@ -109,8 +109,8 @@ public:
    *
    * @param data a Buffer containing protocol data
    * @param buffer_underflow bool set to true if more data is required to continue decoding
-   * @return FilterStatus::Continue when waiting for filter continuation,
-   *             StopIteration otherwise.
+   * @return FilterStatus::ContinueIteration,PauseIteration,AbortIteration or Retry
+   * filter processing.
    * @throw EnvoyException on protocol errors
    */
   FilterStatus onData(Buffer::Instance& data, bool& buffer_underflow);

--- a/src/meta_protocol_proxy/decoder.h
+++ b/src/meta_protocol_proxy/decoder.h
@@ -109,11 +109,9 @@ public:
    *
    * @param data a Buffer containing protocol data
    * @param buffer_underflow bool set to true if more data is required to continue decoding
-   * @return FilterStatus::ContinueIteration,PauseIteration,AbortIteration or Retry
-   * filter processing.
    * @throw EnvoyException on protocol errors
    */
-  FilterStatus onData(Buffer::Instance& data, bool& buffer_underflow);
+  void onData(Buffer::Instance& data, bool& buffer_underflow);
 
   // It is assumed that all of the protocol parsing are stateless,
   // if there is a state of the need to provide the reset interface call here.

--- a/src/meta_protocol_proxy/decoder_event_handler.h
+++ b/src/meta_protocol_proxy/decoder_event_handler.h
@@ -11,11 +11,13 @@ namespace MetaProtocolProxy {
 
 enum class FilterStatus : uint8_t {
   // Continue filter chain iteration.
-  Continue,
-  // Do not iterate to any of the remaining filters in the chain. Returning
-  // FilterDataStatus::Continue from decodeData()/encodeData() or calling
-  // continueDecoding()/continueEncoding() MUST be called if continued filter iteration is desired.
-  StopIteration,
+  ContinueIteration,
+  // Pause iterating to any of the remaining filters in the chain.
+  // The current message remains in the connection manager to wait to be continued.
+  // ContinueDecoding()/continueEncoding() MUST be called to continue filter iteration.
+  PauseIteration,
+  // Abort the current iterate and remove the current message from the connection manager
+  AbortIteration,
   // Indicates that a retry is required for the reply message received.
   Retry,
 };

--- a/src/meta_protocol_proxy/decoder_event_handler.h
+++ b/src/meta_protocol_proxy/decoder_event_handler.h
@@ -19,7 +19,7 @@ enum class FilterStatus : uint8_t {
   // Abort the current iterate and remove the current message from the connection manager
   AbortIteration,
   // Indicates that a retry is required for the reply message received.
-  Retry,
+  Retry, // Retry has not been supported yet
 };
 
 class MessageDecoder {
@@ -29,7 +29,8 @@ public:
   /**
    * Indicates that the message had been decoded.
    * @param metadata MessageMetadataSharedPtr describing the message
-   * @return FilterStatus to indicate if filter chain iteration should continue
+   * @return FilterStatus to indicate if filter chain iteration should continue,pause,abort, or
+   * retry
    */
   virtual FilterStatus onMessageDecoded(MetadataSharedPtr metadata,
                                         MutationSharedPtr mutation) PURE;

--- a/src/meta_protocol_proxy/filters/filter.h
+++ b/src/meta_protocol_proxy/filters/filter.h
@@ -105,7 +105,7 @@ public:
 
   /**
    * Continue iterating through the filter chain with buffered data. This routine can only be
-   * called if the filter has previously returned StopIteration from one of the DecoderFilter
+   * called if the filter has previously returned PauseIteration from one of the DecoderFilter
    * methods. The connection manager will callbacks to the next filter in the chain. Further note
    * that if the request is not complete, the calling filter may receive further callbacks and must
    * return an appropriate status code depending on what the filter needs to do.
@@ -160,7 +160,7 @@ public:
 
   /**
    * Continue iterating through the filter chain with buffered data. This routine can only be
-   * called if the filter has previously returned StopIteration from one of the DecoderFilter
+   * called if the filter has previously returned PauseIteration from one of the DecoderFilter
    * methods. The connection manager will callbacks to the next filter in the chain. Further note
    * that if the request is not complete, the calling filter may receive further callbacks and must
    * return an appropriate status code depending on what the filter needs to do.

--- a/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
+++ b/src/meta_protocol_proxy/filters/local_ratelimit/local_ratelimit.cc
@@ -37,11 +37,11 @@ FilterStatus LocalRateLimit::onMessageDecoded(MetadataSharedPtr metadata, Mutati
                   fmt::format("meta protocol local rate limit: request '{}' has been rate limited",
                               metadata->getRequestId())}),
         false);
-    return FilterStatus::StopIteration;
+    return FilterStatus::AbortIteration;
   }
 
   ENVOY_STREAM_LOG(debug, "meta protocol local rate limit: onMessageDecoded", *callbacks_);
-  return FilterStatus::Continue;
+  return FilterStatus::ContinueIteration;
 }
 
 void LocalRateLimit::setEncoderFilterCallbacks(EncoderFilterCallbacks& callbacks) {
@@ -49,7 +49,7 @@ void LocalRateLimit::setEncoderFilterCallbacks(EncoderFilterCallbacks& callbacks
 }
 
 FilterStatus LocalRateLimit::onMessageEncoded(MetadataSharedPtr, MutationSharedPtr) {
-  return FilterStatus::Continue;
+  return FilterStatus::ContinueIteration;
 }
 
 void LocalRateLimit::cleanup() {}
@@ -68,4 +68,3 @@ bool LocalRateLimit::shouldRateLimit(MetadataSharedPtr metadata) {
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy
-


### PR DESCRIPTION
The meaning of the StopIteration status is ambiguous: it is used in two scenarios now:

Pause the current iteration of the l7 filter chain and the execution of the filter chain will be resumed later. In this case, the current implementation is fine.
Abort the iteration of the l7 filter chain. In this case, the current implementation results in memory leak since the active message will not be deleted from the connection manager until the downstream connection is closed.
This PR solves this issue by splitting StopIteration into two unambiguous statuses: PauseIteration and AbortIteration

PauseIteration: the filter iteration is paused and will be resumed later, for e.g, waiting for an available connection. The corresponding message remains in the connection manager.
AbortIteration: the filter iteration is aborted, for e.g, the upstream host is not found, and the corresponding message will be deleted from the connection manager.