### PR TITLE
add an idle downstream connection timer.

### DIFF
--- a/api/meta_protocol_proxy/v1alpha/meta_protocol_proxy.proto
+++ b/api/meta_protocol_proxy/v1alpha/meta_protocol_proxy.proto
@@ -42,14 +42,15 @@ message MetaProtocolProxy {
   // The codec which encodes and decodes the application protocol.
   Codec codec = 5;
 
-  // for idle downstream timer.
-  google.protobuf.Duration idle_timeout = 6;
 
   // A list of individual Layer-7 filters that make up the filter chain for requests made to
   // the meta protocol proxy. Order matters as the filters are processed sequentially as
   // request events happen. If no meta_protocol_filters are specified, a default router filter
   // (`aeraki.meta_protocol.filters.router`) is used.
-  repeated MetaProtocolFilter meta_protocol_filters = 7;
+  repeated MetaProtocolFilter meta_protocol_filters = 6;
+
+  // for idle downstream timer.
+  google.protobuf.Duration idle_timeout = 11;
 }
 
 message Rds {

--- a/api/meta_protocol_proxy/v1alpha/meta_protocol_proxy.proto
+++ b/api/meta_protocol_proxy/v1alpha/meta_protocol_proxy.proto
@@ -42,11 +42,14 @@ message MetaProtocolProxy {
   // The codec which encodes and decodes the application protocol.
   Codec codec = 5;
 
+  // for idle downstream timer.
+  google.protobuf.Duration idle_timeout = 6;
+
   // A list of individual Layer-7 filters that make up the filter chain for requests made to
   // the meta protocol proxy. Order matters as the filters are processed sequentially as
   // request events happen. If no meta_protocol_filters are specified, a default router filter
   // (`aeraki.meta_protocol.filters.router`) is used.
-  repeated MetaProtocolFilter meta_protocol_filters = 6;
+  repeated MetaProtocolFilter meta_protocol_filters = 7;
 }
 
 message Rds {

--- a/src/meta_protocol_proxy/config.cc
+++ b/src/meta_protocol_proxy/config.cc
@@ -63,6 +63,13 @@ ConfigImpl::ConfigImpl(const MetaProtocolProxyConfig& config,
       application_protocol_(config.application_protocol()), codecConfig_(config.codec()),
       route_config_provider_manager_(route_config_provider_manager) {
   ENVOY_LOG(trace, "********** MetaProtocolProxy ConfigImpl constructor ***********");
+  //check idle_timer config
+  if (config.has_idle_timeout()) {
+    const uint64_t timeout = DurationUtil::durationToMilliseconds(config.idle_timeout());
+    ENVOY_LOG(debug,"debug for idle_timeout-{}",timeout);
+    idle_timeout_ = std::chrono::milliseconds(timeout);
+  }
+
   switch (config.route_specifier_case()) {
   case aeraki::meta_protocol_proxy::v1alpha::MetaProtocolProxy::RouteSpecifierCase::kRds:
     route_config_provider_ = route_config_provider_manager_.createRdsRouteConfigProvider(

--- a/src/meta_protocol_proxy/config.h
+++ b/src/meta_protocol_proxy/config.h
@@ -82,7 +82,7 @@ public:
   Route::Config& routerConfig() override { return *this; }
   Codec& createCodec() override;
   std::string applicationProtocol() override { return application_protocol_; };
-
+  absl::optional<std::chrono::milliseconds> idleTimeout() override { return idle_timeout_;};
 private:
   void registerFilter(const MetaProtocolFilterConfig& proto_config);
 
@@ -96,6 +96,7 @@ private:
   Route::RouteConfigProviderSharedPtr route_config_provider_;
   Route::RouteConfigProviderManager& route_config_provider_manager_;
   std::map<std::string, CodecPtr> codec_map_;
+  absl::optional<std::chrono::milliseconds> idle_timeout_;
 };
 
 } // namespace MetaProtocolProxy

--- a/src/meta_protocol_proxy/conn_manager.cc
+++ b/src/meta_protocol_proxy/conn_manager.cc
@@ -40,6 +40,12 @@ Network::FilterStatus ConnectionManager::onData(Buffer::Instance& data, bool end
 }
 
 Network::FilterStatus ConnectionManager::onNewConnection() {
+  //init idle timer.
+  if(config_.idleTimeout()){
+    idle_timer_ = read_callbacks_->connection().dispatcher().createTimer(
+        [this]() { this->onIdleTimeout(); });  
+    resetIdleTimer();           
+  }
   return Network::FilterStatus::Continue;
 }
 
@@ -52,8 +58,10 @@ void ConnectionManager::initializeReadFilterCallbacks(Network::ReadFilterCallbac
 
 void ConnectionManager::onEvent(Network::ConnectionEvent event) {
   if (event == Network::ConnectionEvent::LocalClose) {
+    disableIdleTimer();
     resetAllMessages(true);
   } else if (event == Network::ConnectionEvent::RemoteClose) {
+    disableIdleTimer();
     resetAllMessages(false);
   }
 }
@@ -97,7 +105,8 @@ void ConnectionManager::dispatch() {
     ENVOY_LOG(debug, "meta protocol: it's empty data");
     return;
   }
-
+  //when data is not empty,it will enable timer again.
+  resetIdleTimer();
   try {
     bool underflow = false;
     // decoder return underflow in th following two cases:
@@ -196,6 +205,28 @@ void ConnectionManager::resetAllMessages(bool local_reset) {
     }
 
     active_message_list_.front()->onReset();
+  }
+}
+
+void ConnectionManager::onIdleTimeout() {
+  ENVOY_CONN_LOG(debug, "meta protocol:Session timed out", read_callbacks_->connection());
+  stats_.idle_timeout_.inc();
+  resetAllMessages(true);
+  clearStream();
+  read_callbacks_->connection().close(Network::ConnectionCloseType::NoFlush);
+}
+
+void ConnectionManager::resetIdleTimer() {
+  if (idle_timer_ != nullptr) {
+    ASSERT(config_.idleTimeout());
+    idle_timer_->enableTimer(config_.idleTimeout().value());
+  }
+}
+
+void ConnectionManager::disableIdleTimer() {
+  if (idle_timer_ != nullptr) {
+    idle_timer_->disableTimer();
+    idle_timer_.reset();
   }
 }
 

--- a/src/meta_protocol_proxy/conn_manager.h
+++ b/src/meta_protocol_proxy/conn_manager.h
@@ -16,6 +16,7 @@
 #include "src/meta_protocol_proxy/stats.h"
 #include "src/meta_protocol_proxy/route/rds.h"
 #include "src/meta_protocol_proxy/stream.h"
+#include "envoy/event/timer.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -90,6 +91,13 @@ private:
   void dispatch();
   void resetAllMessages(bool local_reset);
 
+  //This function is to deal with idle downstream's connection timeout. 
+  void onIdleTimeout();
+  //Reset the timer.
+  void resetIdleTimer();
+  //Disable the timer
+  void disableIdleTimer();
+
   Buffer::OwnedImpl request_buffer_;
   std::list<ActiveMessagePtr> active_message_list_;
   std::map<uint64_t, StreamPtr> active_stream_map_;
@@ -102,6 +110,8 @@ private:
   Codec& codec_;
   RequestDecoderPtr decoder_;
   Network::ReadFilterCallbacks* read_callbacks_{};
+  //timer for idle timeout
+  Event::TimerPtr idle_timer_;
 };
 
 } // namespace MetaProtocolProxy

--- a/src/meta_protocol_proxy/stats.h
+++ b/src/meta_protocol_proxy/stats.h
@@ -34,7 +34,8 @@ namespace MetaProtocolProxy {
   COUNTER(response_error_caused_connection_close)                                                  \
   COUNTER(response_success)                                                                        \
   GAUGE(request_active, Accumulate)                                                                \
-  HISTOGRAM(request_time_ms, Milliseconds)
+  HISTOGRAM(request_time_ms, Milliseconds)                                                         \
+  COUNTER(idle_timeout)                                                                            
 
 /**
  * Struct definition for all meta protocol  proxy stats. @see stats_macros.h

--- a/test/idle_timeout/test.yaml
+++ b/test/idle_timeout/test.yaml
@@ -1,0 +1,44 @@
+admin:
+  access_log_path: ./envoy_debug.log
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 15000
+static_resources:
+  listeners:
+    name: listener_meta_protocol
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 20000
+    filter_chains:
+    - filters:
+      - name: aeraki.meta_protocol_proxy
+        typed_config:
+          '@type': type.googleapis.com/aeraki.meta_protocol_proxy.v1alpha.MetaProtocolProxy
+          application_protocol: brpc
+          codec:
+            name: aeraki.meta_protocol.codec.brpc
+          metaProtocolFilters:
+          - name: aeraki.meta_protocol.filters.router
+          idle_timeout: 5s #default is ms
+          routeConfig:
+            routes:
+            - name: default
+              route:
+                cluster: outbound|20000||demo.brpc.server
+          statPrefix: outbound|20000||demo.brpc.server
+
+  clusters:
+    name: outbound|20000||demo.brpc.server
+    type: STATIC
+    connect_timeout: 5s
+    load_assignment:
+      cluster_name: outbound|20000||demo.brpc.server
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 20001


### PR DESCRIPTION
1、this timer is for idle downstream connection timeout
2、this timer default is ms,you also can set second in field "idle_timeout" of configuration.
3、before you make build,you should make api first,because the config proto has changed,you should protoc it.