### PR TITLE
Metadata exchange filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ api:
 	bazel build //api/meta_protocol_proxy/filters/router/v1alpha:pkg_go_proto && \
 	bazel build //api/meta_protocol_proxy/filters/local_ratelimit/v1alpha:pkg_go_proto && \
 	bazel build //api/meta_protocol_proxy/filters/global_ratelimit/v1alpha:pkg_go_proto && \
+	bazel build //api/meta_protocol_proxy/filters/metadata_exchange/v1alpha:pkg_go_proto && \
 	bazel build //api/meta_protocol_proxy/config/route/v1alpha:pkg_go_proto
 
 clean:

--- a/api/meta_protocol_proxy/filters/metadata_exchange/v1alpha/BUILD
+++ b/api/meta_protocol_proxy/filters/metadata_exchange/v1alpha/BUILD
@@ -1,0 +1,10 @@
+# compile proto
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
+
+licenses(["notice"])  # Apache 2
+
+api_proto_package(
+     deps = [
+        "@com_github_cncf_udpa//udpa/annotations:pkg",
+     ],
+)

--- a/api/meta_protocol_proxy/filters/metadata_exchange/v1alpha/metadata_exchange.proto
+++ b/api/meta_protocol_proxy/filters/metadata_exchange/v1alpha/metadata_exchange.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package aeraki.meta_protocol_proxy.filters.metadata_exchange.v1alpha;
+
+option java_package = "net.aeraki.meta_protocol_proxy.filters.metadata_exchange.v1alpha";
+option java_outer_classname = "MetadataExchangeProto";
+option java_multiple_files = true;
+option go_package = "github.com/aeraki-mesh/meta-protocol-control-plane-api/meta_protocol_proxy/filters/metadata_exchange/v1alpha;metadataexchangev1alpha";
+option (udpa.annotations.file_status).package_version_status = ACTIVE;
+
+// [#protodoc-title: metadata exchange]
+message MetadataExchange {
+}

--- a/api/meta_protocol_proxy/filters/metadata_exchange/v1alpha/metadata_exchange.proto
+++ b/api/meta_protocol_proxy/filters/metadata_exchange/v1alpha/metadata_exchange.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package aeraki.meta_protocol_proxy.filters.metadata_exchange.v1alpha;
 
+import "udpa/annotations/status.proto";
+
 option java_package = "net.aeraki.meta_protocol_proxy.filters.metadata_exchange.v1alpha";
 option java_outer_classname = "MetadataExchangeProto";
 option java_multiple_files = true;

--- a/src/meta_protocol_proxy/BUILD
+++ b/src/meta_protocol_proxy/BUILD
@@ -23,6 +23,7 @@ envoy_cc_library(
         "//src/meta_protocol_proxy/filters/router:router_lib",
         "//src/meta_protocol_proxy/filters/global_ratelimit:config",
         "//src/meta_protocol_proxy/filters/local_ratelimit:config",
+        "//src/meta_protocol_proxy/filters/metadata_exchange:config",
         "//src/meta_protocol_proxy/tracing:tracer_manager_lib",
         "//src/meta_protocol_proxy/tracing:tracer_config_lib",
         "//src/meta_protocol_proxy/tracing:tracer_lib",

--- a/src/meta_protocol_proxy/filters/metadata_exchange/BUILD
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/BUILD
@@ -23,14 +23,13 @@ envoy_cc_library(
     name = "metadata_exchange",
     repository = "@envoy",
     srcs = ["metadata_exchange.cc"],
-    hdrs = ["metadata_exchange.h"],
+    hdrs = ["metadata_exchange.h", "base64.h"],
     deps = [
         "//src/meta_protocol_proxy:codec_impl_lib",
         "//api/meta_protocol_proxy/filters/metadata_exchange/v1alpha:pkg_cc_proto",
         "//api/meta_protocol_proxy/v1alpha:pkg_cc_proto",
         "//src/meta_protocol_proxy:app_exception_lib",
         "//src/meta_protocol_proxy/filters:filter_interface",
-        "@envoy//envoy/upstream:cluster_manager_interface",
         "@envoy//source/common/common:logger_lib",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_protobuf//:protobuf",
@@ -40,5 +39,6 @@ envoy_cc_library(
         "@envoy//envoy/stats:stats_interface",
         "@envoy//envoy/network:connection_interface",
         "@envoy//source/common/http:header_utility_lib",
+	"@io_istio_proxy//extensions/common:proto_util",
     ],
 )

--- a/src/meta_protocol_proxy/filters/metadata_exchange/BUILD
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/BUILD
@@ -1,0 +1,44 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache 2
+
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library")
+
+envoy_cc_library(
+    name = "config",
+    repository = "@envoy",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    deps = [
+        ":metadata_exchange",
+        "//api/meta_protocol_proxy/filters/metadata_exchange/v1alpha:pkg_cc_proto",
+        "//api/meta_protocol_proxy/v1alpha:pkg_cc_proto",
+        "//src/meta_protocol_proxy/filters:factory_base_lib",
+        "//src/meta_protocol_proxy/filters:filter_config_interface",
+        "@envoy//envoy/registry",
+    ],
+)
+
+envoy_cc_library(
+    name = "metadata_exchange",
+    repository = "@envoy",
+    srcs = ["metadata_exchange.cc"],
+    hdrs = ["metadata_exchange.h"],
+    deps = [
+        "//src/meta_protocol_proxy:codec_impl_lib",
+        "//api/meta_protocol_proxy/filters/metadata_exchange/v1alpha:pkg_cc_proto",
+        "//api/meta_protocol_proxy/v1alpha:pkg_cc_proto",
+        "//src/meta_protocol_proxy:app_exception_lib",
+        "//src/meta_protocol_proxy/filters:filter_interface",
+        "@envoy//envoy/upstream:cluster_manager_interface",
+        "@envoy//source/common/common:logger_lib",
+        "@com_github_grpc_grpc//:grpc++",
+        "@com_google_protobuf//:protobuf",
+        "@envoy//envoy/upstream:load_balancer_interface",
+        "@envoy//envoy/upstream:thread_local_cluster_interface",
+        "@envoy//source/common/upstream:load_balancer_lib",
+        "@envoy//envoy/stats:stats_interface",
+        "@envoy//envoy/network:connection_interface",
+        "@envoy//source/common/http:header_utility_lib",
+    ],
+)

--- a/src/meta_protocol_proxy/filters/metadata_exchange/base64.h
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/base64.h
@@ -1,0 +1,200 @@
+/* Copyright 2019 Istio Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * From
+ * https://github.com/envoyproxy/envoy/blob/master/source/common/common/base64.{h,cc}
+ */
+
+#pragma once
+
+#include <string>
+
+static const std::string EMPTY_STRING;
+
+class Base64 {
+ public:
+  static std::string encode(const char* input, uint64_t length,
+                            bool add_padding);
+  static std::string encode(const char* input, uint64_t length) {
+    return encode(input, length, true);
+  }
+  static std::string decodeWithoutPadding(std::string_view input);
+};
+
+// clang-format off
+inline constexpr char CHAR_TABLE[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+inline constexpr unsigned char REVERSE_LOOKUP_TABLE[256] = {
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
+    52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64, 64, 0,  1,  2,  3,  4,  5,  6,
+    7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
+    64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
+    49, 50, 51, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64};
+// clang-format on
+
+inline bool decodeBase(const uint8_t cur_char, uint64_t pos, std::string& ret,
+                       const unsigned char* const reverse_lookup_table) {
+  const unsigned char c = reverse_lookup_table[static_cast<uint32_t>(cur_char)];
+  if (c == 64) {
+    // Invalid character
+    return false;
+  }
+
+  switch (pos % 4) {
+    case 0:
+      ret.push_back(c << 2);
+      break;
+    case 1:
+      ret.back() |= c >> 4;
+      ret.push_back(c << 4);
+      break;
+    case 2:
+      ret.back() |= c >> 2;
+      ret.push_back(c << 6);
+      break;
+    case 3:
+      ret.back() |= c;
+      break;
+  }
+  return true;
+}
+
+inline bool decodeLast(const uint8_t cur_char, uint64_t pos, std::string& ret,
+                       const unsigned char* const reverse_lookup_table) {
+  const unsigned char c = reverse_lookup_table[static_cast<uint32_t>(cur_char)];
+  if (c == 64) {
+    // Invalid character
+    return false;
+  }
+
+  switch (pos % 4) {
+    case 0:
+      return false;
+    case 1:
+      ret.back() |= c >> 4;
+      return (c & 0b1111) == 0;
+    case 2:
+      ret.back() |= c >> 2;
+      return (c & 0b11) == 0;
+    case 3:
+      ret.back() |= c;
+      break;
+  }
+  return true;
+}
+
+inline void encodeBase(const uint8_t cur_char, uint64_t pos, uint8_t& next_c,
+                       std::string& ret, const char* const char_table) {
+  switch (pos % 3) {
+    case 0:
+      ret.push_back(char_table[cur_char >> 2]);
+      next_c = (cur_char & 0x03) << 4;
+      break;
+    case 1:
+      ret.push_back(char_table[next_c | (cur_char >> 4)]);
+      next_c = (cur_char & 0x0f) << 2;
+      break;
+    case 2:
+      ret.push_back(char_table[next_c | (cur_char >> 6)]);
+      ret.push_back(char_table[cur_char & 0x3f]);
+      next_c = 0;
+      break;
+  }
+}
+
+inline void encodeLast(uint64_t pos, uint8_t last_char, std::string& ret,
+                       const char* const char_table, bool add_padding) {
+  switch (pos % 3) {
+    case 1:
+      ret.push_back(char_table[last_char]);
+      if (add_padding) {
+        ret.push_back('=');
+        ret.push_back('=');
+      }
+      break;
+    case 2:
+      ret.push_back(char_table[last_char]);
+      if (add_padding) {
+        ret.push_back('=');
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+inline std::string Base64::encode(const char* input, uint64_t length,
+                                  bool add_padding) {
+  uint64_t output_length = (length + 2) / 3 * 4;
+  std::string ret;
+  ret.reserve(output_length);
+
+  uint64_t pos = 0;
+  uint8_t next_c = 0;
+
+  for (uint64_t i = 0; i < length; ++i) {
+    encodeBase(input[i], pos++, next_c, ret, CHAR_TABLE);
+  }
+
+  encodeLast(pos, next_c, ret, CHAR_TABLE, add_padding);
+
+  return ret;
+}
+
+inline std::string Base64::decodeWithoutPadding(std::string_view input) {
+  if (input.empty()) {
+    return EMPTY_STRING;
+  }
+
+  // At most last two chars can be '='.
+  size_t n = input.length();
+  if (input[n - 1] == '=') {
+    n--;
+    if (n > 0 && input[n - 1] == '=') {
+      n--;
+    }
+  }
+  // Last position before "valid" padding character.
+  uint64_t last = n - 1;
+  // Determine output length.
+  size_t max_length = (n + 3) / 4 * 3;
+  if (n % 4 == 3) {
+    max_length -= 1;
+  }
+  if (n % 4 == 2) {
+    max_length -= 2;
+  }
+
+  std::string ret;
+  ret.reserve(max_length);
+  for (uint64_t i = 0; i < last; ++i) {
+    if (!decodeBase(input[i], i, ret, REVERSE_LOOKUP_TABLE)) {
+      return EMPTY_STRING;
+    }
+  }
+
+  if (!decodeLast(input[last], last, ret, REVERSE_LOOKUP_TABLE)) {
+    return EMPTY_STRING;
+  }
+
+  ASSERT(ret.size() == max_length);
+  return ret;
+}

--- a/src/meta_protocol_proxy/filters/metadata_exchange/base64.h
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/base64.h
@@ -23,9 +23,8 @@
 static const std::string EMPTY_STRING;
 
 class Base64 {
- public:
-  static std::string encode(const char* input, uint64_t length,
-                            bool add_padding);
+public:
+  static std::string encode(const char* input, uint64_t length, bool add_padding);
   static std::string encode(const char* input, uint64_t length) {
     return encode(input, length, true);
   }
@@ -59,20 +58,20 @@ inline bool decodeBase(const uint8_t cur_char, uint64_t pos, std::string& ret,
   }
 
   switch (pos % 4) {
-    case 0:
-      ret.push_back(c << 2);
-      break;
-    case 1:
-      ret.back() |= c >> 4;
-      ret.push_back(c << 4);
-      break;
-    case 2:
-      ret.back() |= c >> 2;
-      ret.push_back(c << 6);
-      break;
-    case 3:
-      ret.back() |= c;
-      break;
+  case 0:
+    ret.push_back(c << 2);
+    break;
+  case 1:
+    ret.back() |= c >> 4;
+    ret.push_back(c << 4);
+    break;
+  case 2:
+    ret.back() |= c >> 2;
+    ret.push_back(c << 6);
+    break;
+  case 3:
+    ret.back() |= c;
+    break;
   }
   return true;
 }
@@ -86,63 +85,62 @@ inline bool decodeLast(const uint8_t cur_char, uint64_t pos, std::string& ret,
   }
 
   switch (pos % 4) {
-    case 0:
-      return false;
-    case 1:
-      ret.back() |= c >> 4;
-      return (c & 0b1111) == 0;
-    case 2:
-      ret.back() |= c >> 2;
-      return (c & 0b11) == 0;
-    case 3:
-      ret.back() |= c;
-      break;
+  case 0:
+    return false;
+  case 1:
+    ret.back() |= c >> 4;
+    return (c & 0b1111) == 0;
+  case 2:
+    ret.back() |= c >> 2;
+    return (c & 0b11) == 0;
+  case 3:
+    ret.back() |= c;
+    break;
   }
   return true;
 }
 
-inline void encodeBase(const uint8_t cur_char, uint64_t pos, uint8_t& next_c,
-                       std::string& ret, const char* const char_table) {
+inline void encodeBase(const uint8_t cur_char, uint64_t pos, uint8_t& next_c, std::string& ret,
+                       const char* const char_table) {
   switch (pos % 3) {
-    case 0:
-      ret.push_back(char_table[cur_char >> 2]);
-      next_c = (cur_char & 0x03) << 4;
-      break;
-    case 1:
-      ret.push_back(char_table[next_c | (cur_char >> 4)]);
-      next_c = (cur_char & 0x0f) << 2;
-      break;
-    case 2:
-      ret.push_back(char_table[next_c | (cur_char >> 6)]);
-      ret.push_back(char_table[cur_char & 0x3f]);
-      next_c = 0;
-      break;
+  case 0:
+    ret.push_back(char_table[cur_char >> 2]);
+    next_c = (cur_char & 0x03) << 4;
+    break;
+  case 1:
+    ret.push_back(char_table[next_c | (cur_char >> 4)]);
+    next_c = (cur_char & 0x0f) << 2;
+    break;
+  case 2:
+    ret.push_back(char_table[next_c | (cur_char >> 6)]);
+    ret.push_back(char_table[cur_char & 0x3f]);
+    next_c = 0;
+    break;
   }
 }
 
 inline void encodeLast(uint64_t pos, uint8_t last_char, std::string& ret,
                        const char* const char_table, bool add_padding) {
   switch (pos % 3) {
-    case 1:
-      ret.push_back(char_table[last_char]);
-      if (add_padding) {
-        ret.push_back('=');
-        ret.push_back('=');
-      }
-      break;
-    case 2:
-      ret.push_back(char_table[last_char]);
-      if (add_padding) {
-        ret.push_back('=');
-      }
-      break;
-    default:
-      break;
+  case 1:
+    ret.push_back(char_table[last_char]);
+    if (add_padding) {
+      ret.push_back('=');
+      ret.push_back('=');
+    }
+    break;
+  case 2:
+    ret.push_back(char_table[last_char]);
+    if (add_padding) {
+      ret.push_back('=');
+    }
+    break;
+  default:
+    break;
   }
 }
 
-inline std::string Base64::encode(const char* input, uint64_t length,
-                                  bool add_padding) {
+inline std::string Base64::encode(const char* input, uint64_t length, bool add_padding) {
   uint64_t output_length = (length + 2) / 3 * 4;
   std::string ret;
   ret.reserve(output_length);

--- a/src/meta_protocol_proxy/filters/metadata_exchange/config.cc
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/config.cc
@@ -1,7 +1,7 @@
 #include "src/meta_protocol_proxy/filters/metadata_exchange/config.h"
 
 #include "envoy/registry/registry.h"
-#include "src/meta_protocol_proxy/filters/metadata_exchange/metadata_excahange.h"
+#include "src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h"
 
 namespace Envoy {
 namespace Extensions {

--- a/src/meta_protocol_proxy/filters/metadata_exchange/config.cc
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/config.cc
@@ -12,10 +12,11 @@ namespace MetadataExchange {
 FilterFactoryCb MetadataExchangeFilterConfig::createFilterFactoryFromProtoTyped(
     const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange& cfg,
     const std::string&, Server::Configuration::FactoryContext& context) {
-
-  // cfg is changed
-  return [cfg, &context](FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addFilter(std::make_shared<MetadataExchangeFilter>(cfg, context.localInfo()));
+  context.direction()
+      // cfg is changed
+      return [cfg, &context](FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addFilter(std::make_shared<MetadataExchangeFilter>(
+        cfg, Server::Configuration::FactoryContext & context));
   };
 }
 

--- a/src/meta_protocol_proxy/filters/metadata_exchange/config.cc
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/config.cc
@@ -12,11 +12,9 @@ namespace MetadataExchange {
 FilterFactoryCb MetadataExchangeFilterConfig::createFilterFactoryFromProtoTyped(
     const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange& cfg,
     const std::string&, Server::Configuration::FactoryContext& context) {
-  context.direction()
       // cfg is changed
       return [cfg, &context](FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addFilter(std::make_shared<MetadataExchangeFilter>(
-        cfg, Server::Configuration::FactoryContext & context));
+    callbacks.addFilter(std::make_shared<MetadataExchangeFilter>(cfg, context));
   };
 }
 

--- a/src/meta_protocol_proxy/filters/metadata_exchange/config.cc
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/config.cc
@@ -15,7 +15,7 @@ FilterFactoryCb MetadataExchangeFilterConfig::createFilterFactoryFromProtoTyped(
 
   // cfg is changed
   return [cfg, &context](FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addFilter(std::make_shared<MetadataExchangeFilter>(context.clusterManager(), cfg));
+    callbacks.addFilter(std::make_shared<MetadataExchangeFilter>(cfg, context.localInfo()));
   };
 }
 

--- a/src/meta_protocol_proxy/filters/metadata_exchange/config.cc
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/config.cc
@@ -1,0 +1,31 @@
+#include "src/meta_protocol_proxy/filters/metadata_exchange/config.h"
+
+#include "envoy/registry/registry.h"
+#include "src/meta_protocol_proxy/filters/metadata_exchange/metadata_excahange.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace MetaProtocolProxy {
+namespace MetadataExchange {
+
+FilterFactoryCb MetadataExchangeFilterConfig::createFilterFactoryFromProtoTyped(
+    const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange& cfg,
+    const std::string&, Server::Configuration::FactoryContext& context) {
+
+  // cfg is changed
+  return [cfg, &context](FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addFilter(std::make_shared<MetadataExchangeFilter>(context.clusterManager(), cfg));
+  };
+}
+
+/**
+ * Static registration for the router filter. @see RegisterFactory.
+ */
+REGISTER_FACTORY(MetadataExchangeFilterConfig, NamedMetaProtocolFilterConfigFactory);
+
+} // namespace MetadataExchange
+} // namespace MetaProtocolProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/src/meta_protocol_proxy/filters/metadata_exchange/config.h
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/config.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "api/meta_protocol_proxy/filters/metadata_exchange/v1alpha/metadata_exchange.pb.h"
+#include "api/meta_protocol_proxy/filters/metadata_exchange/v1alpha/metadata_exchange.pb.validate.h"
+#include "src/meta_protocol_proxy/filters/factory_base.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace MetaProtocolProxy {
+namespace MetadataExchange {
+
+class MetadataExchangeFilterConfig
+    : public FactoryBase<
+          aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange> {
+public:
+  MetadataExchangeFilterConfig() : FactoryBase("aeraki.meta_protocol.filters.metadata_exchange") {}
+
+private:
+  FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange&
+          proto_config,
+      const std::string& stat_prefix, Server::Configuration::FactoryContext& context) override;
+};
+
+} // namespace MetadataExchange
+} // namespace MetaProtocolProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.cc
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.cc
@@ -9,29 +9,16 @@ namespace NetworkFilters {
 namespace MetaProtocolProxy {
 namespace MetadataExchange {
 
-void MetadataExchangeFilter::onDestroy() { cleanup(); }
-
-void MetadataExchangeFilter::setDecoderFilterCallbacks(DecoderFilterCallbacks& callbacks) {
-  callbacks_ = &callbacks;
-}
-
-FilterStatus MetadataExchangeFilter::onMessageDecoded(MetadataSharedPtr,
-                                                      MutationSharedPtr) {
-  ENVOY_LOG(info, "xxxxxxxxxx meta protocol: metadata exchange ondecode");	
+FilterStatus MetadataExchangeFilter::onMessageDecoded(MetadataSharedPtr, MutationSharedPtr) {
+  ENVOY_LOG(info, "xxxxxxxxxx meta protocol: metadata exchange ondecode");
   return FilterStatus::ContinueIteration;
-}
-
-void MetadataExchangeFilter::setEncoderFilterCallbacks(EncoderFilterCallbacks& callbacks) {
-  encoder_callbacks_ = &callbacks;
 }
 
 FilterStatus MetadataExchangeFilter::onMessageEncoded(MetadataSharedPtr, MutationSharedPtr) {
 
-  ENVOY_LOG(info, "xxxxxxxxxxx meta protocol: metadata exchange onencode");	
+  ENVOY_LOG(info, "xxxxxxxxxxx meta protocol: metadata exchange onencode");
   return FilterStatus::ContinueIteration;
 }
-
-void MetadataExchangeFilter::cleanup() {}
 
 } // namespace MetadataExchange
 } // namespace  MetaProtocolProxy

--- a/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.cc
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.cc
@@ -1,23 +1,41 @@
 #include "src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h"
 #include "src/meta_protocol_proxy/app_exception.h"
 #include "source/common/buffer/buffer_impl.h"
-#include "src/meta_protocol_proxy/codec_impl.h"
+
+#include "src/meta_protocol_proxy/filters/metadata_exchange/base64.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
 namespace MetaProtocolProxy {
 namespace MetadataExchange {
+MetadataExchangeFilter::MetadataExchangeFilter(
+      const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange&,
+      const LocalInfo::LocalInfo& local_info){
+      loadMetadataFromNodeInfo(local_info);
+  }
 
-FilterStatus MetadataExchangeFilter::onMessageDecoded(MetadataSharedPtr, MutationSharedPtr) {
-  ENVOY_LOG(info, "xxxxxxxxxx meta protocol: metadata exchange ondecode");
+FilterStatus MetadataExchangeFilter::onMessageDecoded(MetadataSharedPtr, MutationSharedPtr mutation) {
+  (*mutation.get())[ExchangeMetadataHeader] = metadata_;
+  (*mutation.get())[ExchangeMetadataHeaderId] = metadata_id_;
   return FilterStatus::ContinueIteration;
 }
 
 FilterStatus MetadataExchangeFilter::onMessageEncoded(MetadataSharedPtr, MutationSharedPtr) {
-
-  ENVOY_LOG(info, "xxxxxxxxxxx meta protocol: metadata exchange onencode");
   return FilterStatus::ContinueIteration;
+}
+
+void MetadataExchangeFilter::loadMetadataFromNodeInfo(const LocalInfo::LocalInfo& local_info) {
+  if (local_info.node().has_metadata()) {
+    google::protobuf::Struct metadata;
+    const auto fb = ::Wasm::Common::extractNodeFlatBufferFromStruct(local_info.node().metadata());
+    ::Wasm::Common::extractStructFromNodeFlatBuffer(
+        *flatbuffers::GetRoot<::Wasm::Common::FlatNode>(fb.data()), &metadata);
+    std::string metadata_bytes;
+    ::Wasm::Common::serializeToStringDeterministic(metadata, &metadata_bytes);
+    metadata_ = Base64::encode(metadata_bytes.data(), metadata_bytes.size());
+  }
+  metadata_id_ = local_info.node().id(); 
 }
 
 } // namespace MetadataExchange

--- a/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.cc
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.cc
@@ -12,7 +12,7 @@ namespace MetadataExchange {
 MetadataExchangeFilter::MetadataExchangeFilter(
     const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange&,
     const Server::Configuration::FactoryContext& context) {
-  loadMetadataFromNodeInfo(context.local_info);
+  loadMetadataFromNodeInfo(context.localInfo());
   traffic_direction_ = context.direction();
 }
 

--- a/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.cc
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.cc
@@ -15,8 +15,9 @@ void MetadataExchangeFilter::setDecoderFilterCallbacks(DecoderFilterCallbacks& c
   callbacks_ = &callbacks;
 }
 
-FilterStatus MetadataExchangeFilter::onMessageDecoded(MetadataSharedPtr metadata,
+FilterStatus MetadataExchangeFilter::onMessageDecoded(MetadataSharedPtr,
                                                       MutationSharedPtr) {
+  ENVOY_LOG(info, "xxxxxxxxxx meta protocol: metadata exchange ondecode");	
   return FilterStatus::ContinueIteration;
 }
 
@@ -25,6 +26,8 @@ void MetadataExchangeFilter::setEncoderFilterCallbacks(EncoderFilterCallbacks& c
 }
 
 FilterStatus MetadataExchangeFilter::onMessageEncoded(MetadataSharedPtr, MutationSharedPtr) {
+
+  ENVOY_LOG(info, "xxxxxxxxxxx meta protocol: metadata exchange onencode");	
   return FilterStatus::ContinueIteration;
 }
 

--- a/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.cc
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.cc
@@ -1,0 +1,37 @@
+#include "src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h"
+#include "src/meta_protocol_proxy/app_exception.h"
+#include "source/common/buffer/buffer_impl.h"
+#include "src/meta_protocol_proxy/codec_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace MetaProtocolProxy {
+namespace MetadataExchange {
+
+void MetadataExchangeFilter::onDestroy() { cleanup(); }
+
+void MetadataExchangeFilter::setDecoderFilterCallbacks(DecoderFilterCallbacks& callbacks) {
+  callbacks_ = &callbacks;
+}
+
+FilterStatus MetadataExchangeFilter::onMessageDecoded(MetadataSharedPtr metadata,
+                                                      MutationSharedPtr) {
+  return FilterStatus::ContinueIteration;
+}
+
+void MetadataExchangeFilter::setEncoderFilterCallbacks(EncoderFilterCallbacks& callbacks) {
+  encoder_callbacks_ = &callbacks;
+}
+
+FilterStatus MetadataExchangeFilter::onMessageEncoded(MetadataSharedPtr, MutationSharedPtr) {
+  return FilterStatus::ContinueIteration;
+}
+
+void MetadataExchangeFilter::cleanup() {}
+
+} // namespace MetadataExchange
+} // namespace  MetaProtocolProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <grpcpp/grpcpp.h>
 
-//Envoy
+// Envoy
 #include "envoy/local_info/local_info.h"
 #include "envoy/stats/scope.h"
 #include "envoy/buffer/buffer.h"
@@ -16,7 +16,7 @@
 #include "source/common/upstream/load_balancer_impl.h"
 #include "source/common/http/header_utility.h"
 
-//istio proxy
+// istio proxy
 #include "extensions/common/proto_util.h"
 
 #include "google/protobuf/util/json_util.h"
@@ -39,15 +39,15 @@ class MetadataExchangeFilter : public CodecFilter,
 public:
   MetadataExchangeFilter(
       const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange&,
-      const LocalInfo::LocalInfo& local_info);
+      const Server::Configuration::FactoryContext& context);
   ~MetadataExchangeFilter() override = default;
-  void onDestroy() override {};
+  void onDestroy() override{};
 
   // DecoderFilter
-  void setDecoderFilterCallbacks(DecoderFilterCallbacks& ) override{};
+  void setDecoderFilterCallbacks(DecoderFilterCallbacks&) override{};
   FilterStatus onMessageDecoded(MetadataSharedPtr metadata, MutationSharedPtr mutation) override;
 
-  void setEncoderFilterCallbacks(EncoderFilterCallbacks& ) override {};
+  void setEncoderFilterCallbacks(EncoderFilterCallbacks&) override{};
   FilterStatus onMessageEncoded(MetadataSharedPtr, MutationSharedPtr) override;
 
 private:
@@ -58,6 +58,8 @@ private:
   std::string metadata_;
   // use node id as metadata id
   std::string metadata_id_;
+  // traffic direction, inbound or outbound
+  envoy::config::core::v3::TrafficDirection traffic_direction_;
 };
 
 } // namespace MetadataExchange

--- a/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h
@@ -33,6 +33,7 @@ public:
       const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange&,
       const LocalInfo::LocalInfo& local_info& local_info):local_info_(local_info) {}
   ~MetadataExchangeFilter() override = default;
+  void onDestroy() override {};
 
   // DecoderFilter
   void setDecoderFilterCallbacks(DecoderFilterCallbacks& ) override{};

--- a/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h
@@ -14,7 +14,7 @@
 #include "envoy/network/connection.h"
 #include "source/common/http/header_utility.h"
 
-#include "api/meta_protocol_proxy/filters/metadata_exchange/v1alpha/metadata_exchanged.pb.h"
+#include "api/meta_protocol_proxy/filters/metadata_exchange/v1alpha/metadata_exchange.pb.h"
 #include "src/meta_protocol_proxy/filters/filter.h"
 #include "google/protobuf/util/json_util.h"
 
@@ -28,9 +28,8 @@ class MetadataExchangeFilter : public CodecFilter,
                   public Upstream::LoadBalancerContextBase,
                   Logger::Loggable<Logger::Id::filter> {
 public:
-  MetadataExchangeFilter(Envoy::Upstream::ClusterManager& cm,
-            const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange& config)
-      : cluster_manager_(cm) {}
+  MetadataExchangeFilter(Envoy::Upstream::ClusterManager&,
+            const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange&){}
   ~MetadataExchangeFilter() override = default;
 
   void onDestroy() override;
@@ -47,8 +46,6 @@ private:
 
   DecoderFilterCallbacks* callbacks_{};
   EncoderFilterCallbacks* encoder_callbacks_{};
-
-  Upstream::ClusterManager& cluster_manager_;
 };
 
 } // namespace MetadataExchange

--- a/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h
@@ -8,6 +8,7 @@
 #include "envoy/local_info/local_info.h"
 #include "envoy/stats/scope.h"
 #include "envoy/buffer/buffer.h"
+#include "envoy/server/factory_context.h"
 #include "source/common/common/logger.h"
 #include "source/common/buffer/buffer_impl.h"
 #include "envoy/network/connection.h"

--- a/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h
+++ b/src/meta_protocol_proxy/filters/metadata_exchange/metadata_exchange.h
@@ -4,14 +4,15 @@
 #include <string>
 #include <grpcpp/grpcpp.h>
 
+#include "envoy/local_info/local_info.h"
 #include "envoy/stats/scope.h"
 #include "envoy/buffer/buffer.h"
 #include "source/common/common/logger.h"
 #include "source/common/buffer/buffer_impl.h"
-#include "envoy/upstream/cluster_manager.h"
-#include "envoy/upstream/thread_local_cluster.h"
-#include "source/common/upstream/load_balancer_impl.h"
 #include "envoy/network/connection.h"
+
+#include "source/common/protobuf/protobuf.h"
+#include "source/common/upstream/load_balancer_impl.h"
 #include "source/common/http/header_utility.h"
 
 #include "api/meta_protocol_proxy/filters/metadata_exchange/v1alpha/metadata_exchange.pb.h"
@@ -25,27 +26,30 @@ namespace MetaProtocolProxy {
 namespace MetadataExchange {
 
 class MetadataExchangeFilter : public CodecFilter,
-                  public Upstream::LoadBalancerContextBase,
-                  Logger::Loggable<Logger::Id::filter> {
+                               public Upstream::LoadBalancerContextBase,
+                               Logger::Loggable<Logger::Id::filter> {
 public:
-  MetadataExchangeFilter(Envoy::Upstream::ClusterManager&,
-            const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange&){}
+  MetadataExchangeFilter(
+      const aeraki::meta_protocol_proxy::filters::metadata_exchange::v1alpha::MetadataExchange&,
+      const LocalInfo::LocalInfo& local_info& local_info):local_info_(local_info) {}
   ~MetadataExchangeFilter() override = default;
 
-  void onDestroy() override;
-
   // DecoderFilter
-  void setDecoderFilterCallbacks(DecoderFilterCallbacks& callbacks) override;
+  void setDecoderFilterCallbacks(DecoderFilterCallbacks& ) override{};
   FilterStatus onMessageDecoded(MetadataSharedPtr metadata, MutationSharedPtr mutation) override;
 
-  void setEncoderFilterCallbacks(EncoderFilterCallbacks& callbacks) override;
+  void setEncoderFilterCallbacks(EncoderFilterCallbacks& ) override {};
   FilterStatus onMessageEncoded(MetadataSharedPtr, MutationSharedPtr) override;
 
 private:
-  void cleanup();
+  // Helper function to get node metadata.
+  void getMetadata(google::protobuf::Struct* metadata);
 
-  DecoderFilterCallbacks* callbacks_{};
-  EncoderFilterCallbacks* encoder_callbacks_{};
+  // Helper function to get metadata id.
+  std::string getMetadataId();
+
+  // LocalInfo instance.
+  const LocalInfo::LocalInfo& local_info_;
 };
 
 } // namespace MetadataExchange

--- a/test/dubbo/test.sh
+++ b/test/dubbo/test.sh
@@ -6,5 +6,5 @@ docker run -d -p 20881:20880 --name provider aeraki/dubbo-sample-provider
 docker run -d -p 20882:20880 --name mirror-provider aeraki/dubbo-sample-provider
 sudo docker run -d --name jaeger --env COLLECTOR_ZIPKIN_HOST_PORT=":9411" -p 14268:14268 -p 16686:16686 -p 9411:9411 jaegertracing/all-in-one:1.22
 kill `ps -ef | awk '/bazel-bin\/envoy/{print $2}'`
-$BASEDIR/../../bazel-bin/envoy -c $BASEDIR/test.yaml -l info&
+$BASEDIR/../../bazel-bin/envoy -c $BASEDIR/test.yaml -l debug&
 sudo docker logs -f consumer

--- a/test/dubbo/test.yaml
+++ b/test/dubbo/test.yaml
@@ -6,6 +6,43 @@ admin:
       port_value: 8080
 node:
   cluster: dubbo-sample-consumer.metaprotocol
+  id: sidecar~10.244.0.14~dubbo-sample-consumer-797c4f7cc4-t678c.meta-dubbo~meta-dubbo.svc.cluster.local
+  locality: {}
+  metadata:
+    ANNOTATIONS:
+      kubectl.kubernetes.io/default-container: dubbo-sample-consumer
+      kubectl.kubernetes.io/default-logs-container: dubbo-sample-consumer
+      kubernetes.io/config.seen: "2023-01-25T10:10:50.847802347Z"
+      kubernetes.io/config.source: api
+      prometheus.io/path: /stats/prometheus
+      prometheus.io/port: "15020"
+      prometheus.io/scrape: "true"
+      sidecar.istio.io/bootstrapOverride: aeraki-bootstrap-config
+      sidecar.istio.io/proxyImage: aeraki/meta-protocol-proxy-debug:1.2.2
+      sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","custom-bootstrap-volume","istio-envoy","istio-data","istio-podinfo","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
+    APP_CONTAINERS: dubbo-sample-consumer
+    CLUSTER_ID: Kubernetes
+    INTERCEPTION_MODE: REDIRECT
+    LABELS:
+      app: dubbo-sample-consumer
+      pod-template-hash: 797c4f7cc4
+      security.istio.io/tlsMode: istio
+      service.istio.io/canonical-name: dubbo-sample-consumer
+      service.istio.io/canonical-revision: latest
+    MESH_ID: cluster.local
+    NAME: dubbo-sample-consumer-797c4f7cc4-t678c
+    NAMESPACE: meta-dubbo
+    OWNER: kubernetes://apis/apps/v1/namespaces/meta-dubbo/deployments/dubbo-sample-consumer
+    PROXY_CONFIG:
+      binaryPath: /usr/local/bin/envoy
+      controlPlaneAuthPolicy: MUTUAL_TLS
+      discoveryAddress: istiod.istio-system.svc:15012
+      proxyAdminPort: 15000
+      proxyMetadata:
+        ISTIO_META_DNS_CAPTURE: "true"
+      serviceCluster: istio-proxy
+    SERVICE_ACCOUNT: default
+    WORKLOAD_NAME: dubbo-sample-consumer
 tracing:
   http:
     name: envoy.tracers.zipkin

--- a/test/dubbo/test.yaml
+++ b/test/dubbo/test.yaml
@@ -39,6 +39,7 @@ static_resources:
           codec:
             name: aeraki.meta_protocol.codec.dubbo
           metaProtocolFilters:
+          - name: aeraki.meta_protocol.filters.metadata_exchange
           - name: aeraki.meta_protocol.filters.router
           routeConfig:
             routes:

--- a/test/dubbo/test.yaml
+++ b/test/dubbo/test.yaml
@@ -7,19 +7,10 @@ admin:
 node:
   cluster: dubbo-sample-consumer.metaprotocol
   id: sidecar~10.244.0.14~dubbo-sample-consumer-797c4f7cc4-t678c.meta-dubbo~meta-dubbo.svc.cluster.local
-  locality: {}
   metadata:
     ANNOTATIONS:
       kubectl.kubernetes.io/default-container: dubbo-sample-consumer
       kubectl.kubernetes.io/default-logs-container: dubbo-sample-consumer
-      kubernetes.io/config.seen: "2023-01-25T10:10:50.847802347Z"
-      kubernetes.io/config.source: api
-      prometheus.io/path: /stats/prometheus
-      prometheus.io/port: "15020"
-      prometheus.io/scrape: "true"
-      sidecar.istio.io/bootstrapOverride: aeraki-bootstrap-config
-      sidecar.istio.io/proxyImage: aeraki/meta-protocol-proxy-debug:1.2.2
-      sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","workload-certs","custom-bootstrap-volume","istio-envoy","istio-data","istio-podinfo","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
     APP_CONTAINERS: dubbo-sample-consumer
     CLUSTER_ID: Kubernetes
     INTERCEPTION_MODE: REDIRECT
@@ -60,6 +51,7 @@ static_resources:
       socket_address:
         address: 0.0.0.0
         port_value: 20880
+    traffic_direction: OUTBOUND
     filter_chains:
     - filters:
       - name: aeraki.meta_protocol_proxy


### PR DESCRIPTION
send node metadata via metaprotocol headers to the other side, as we need it to generate source labels in the metrics.

 This pr is part of https://github.com/aeraki-mesh/aeraki/issues/196